### PR TITLE
Fix / make cli-plugin-abtest proof against field adds in abtester's status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- [finish] Filter (remove `undefined`s) workspaces list before prompting
+
 ## [0.1.1] - 2021-03-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ npm install -g @vtex/cli-plugin-abtest
 $ oclif-example COMMAND
 running command...
 $ oclif-example (-v|--version|version)
-@vtex/cli-plugin-abtest/0.1.1 linux-x64 node-v12.21.0
+@vtex/cli-plugin-abtest/0.1.1 linux-x64 node-v12.22.0
 $ oclif-example --help [COMMAND]
 USAGE
   $ oclif-example COMMAND

--- a/src/modules/abtest/finish.ts
+++ b/src/modules/abtest/finish.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk'
 import enquirer from 'enquirer'
-import { map, prop } from 'ramda'
+import { map, prop, filter } from 'ramda'
 
 import { logger, promptConfirm, SessionManager } from 'vtex'
 
@@ -21,6 +21,7 @@ const promptWorkspaceToFinishABTest = () =>
   abtester
     .status()
     .then(map(({ WorkspaceB }) => WorkspaceB))
+    .then(filter((workspace: any) => workspace !== undefined))
     // @ts-ignore
     .then((workspaces: string[]) =>
       enquirer.prompt<{ workspace: string }>({

--- a/src/modules/abtest/finish.ts
+++ b/src/modules/abtest/finish.ts
@@ -20,9 +20,8 @@ ${chalk.blue(workspace)}, account ${chalk.green(account)}. Are you sure?`,
 const promptWorkspaceToFinishABTest = () =>
   abtester
     .status()
+    .then(filter(({ WorkspaceB }) => WorkspaceB !== undefined))
     .then(map(({ WorkspaceB }) => WorkspaceB))
-    .then(filter((workspace: any) => workspace !== undefined))
-    // @ts-ignore
     .then((workspaces: string[]) =>
       enquirer.prompt<{ workspace: string }>({
         name: 'workspace',

--- a/yarn.lock
+++ b/yarn.lock
@@ -8052,7 +8052,7 @@ static-extend@^0.1.1, static-extend@^0.1.2:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What is the purpose of this pull request?
New fields additions into `abtester`'s responses are not breaking changes (well... They shouldn't be). The purpose of this PR is to make `cli-plugin-abtest` proof against this kind of change.

#### What problem is this solving?
With its latest update, `vtex.ab-tester` started returning a new value in its `status` route. This value does not have a `WorkspaceB` field. 
When trying to prompt the list of workspaces under test, `cli-plugin-abtest` [has been transforming the new value into `undefined`](https://github.com/vtex/cli-plugin-abtest/blob/47fe8db4688c96020f3890cc23e040ef43376c74/src/modules/abtest/finish.ts#L23). This has been causing problems, as `enquirer.prompt` does not behave well when one of the `choices` values it receives is `undefined`. 
Below, an image of the stack error that `vtex workspace abtest finish` has been returning.

<img width="995" alt="Captura de Tela 2021-04-09 às 16 16 51" src="https://user-images.githubusercontent.com/67928158/114283660-3775d700-9a21-11eb-8dcb-b2b304aee675.png">


#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [ ] Update `CHANGELOG.md`