### PR TITLE
Fix / Allow user to use beta versions of ab-tester

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- [start] Allow the use of beta versions of ab-tester
+
 ## [0.1.2] - 2021-04-12
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3] - 2021-04-20
+
 ### Fixed
 - [start] Allow the use of beta versions of ab-tester
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ npm install -g @vtex/cli-plugin-abtest
 $ oclif-example COMMAND
 running command...
 $ oclif-example (-v|--version|version)
-@vtex/cli-plugin-abtest/0.1.2 linux-x64 node-v12.22.1
+@vtex/cli-plugin-abtest/0.1.3 linux-x64 node-v12.22.1
 $ oclif-example --help [COMMAND]
 USAGE
   $ oclif-example COMMAND
@@ -44,7 +44,7 @@ OPTIONS
   --trace        Ensure all requests to VTEX IO are traced
 ```
 
-_See code: [build/commands/workspace/abtest/finish.ts](https://github.com/vtex/cli-plugin-abtest/blob/v0.1.2/build/commands/workspace/abtest/finish.ts)_
+_See code: [build/commands/workspace/abtest/finish.ts](https://github.com/vtex/cli-plugin-abtest/blob/v0.1.3/build/commands/workspace/abtest/finish.ts)_
 
 ## `oclif-example workspace:abtest:start`
 
@@ -60,7 +60,7 @@ OPTIONS
   --trace        Ensure all requests to VTEX IO are traced
 ```
 
-_See code: [build/commands/workspace/abtest/start.ts](https://github.com/vtex/cli-plugin-abtest/blob/v0.1.2/build/commands/workspace/abtest/start.ts)_
+_See code: [build/commands/workspace/abtest/start.ts](https://github.com/vtex/cli-plugin-abtest/blob/v0.1.3/build/commands/workspace/abtest/start.ts)_
 
 ## `oclif-example workspace:abtest:status`
 
@@ -76,5 +76,5 @@ OPTIONS
   --trace        Ensure all requests to VTEX IO are traced
 ```
 
-_See code: [build/commands/workspace/abtest/status.ts](https://github.com/vtex/cli-plugin-abtest/blob/v0.1.2/build/commands/workspace/abtest/status.ts)_
+_See code: [build/commands/workspace/abtest/status.ts](https://github.com/vtex/cli-plugin-abtest/blob/v0.1.3/build/commands/workspace/abtest/status.ts)_
 <!-- commandsstop -->

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ npm install -g @vtex/cli-plugin-abtest
 $ oclif-example COMMAND
 running command...
 $ oclif-example (-v|--version|version)
-@vtex/cli-plugin-abtest/0.1.2 linux-x64 node-v12.22.0
+@vtex/cli-plugin-abtest/0.1.2 linux-x64 node-v12.22.1
 $ oclif-example --help [COMMAND]
 USAGE
   $ oclif-example COMMAND

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vtex/cli-plugin-abtest",
   "description": "vtex plugin abtest",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "bugs": "https://github.com/vtex/cli-plugin-abtest/issues",
   "dependencies": {
     "@oclif/command": "^1",

--- a/src/modules/abtest/start.ts
+++ b/src/modules/abtest/start.ts
@@ -60,7 +60,8 @@ export default async () => {
   const workspace = await promptProductionWorkspace('Choose production workspace to start A/B test:')
 
   try {
-    if (semver.satisfies(abTesterManifest.version, '>=0.10.0')) {
+    const version = abTesterManifest.version.split('-')[0]
+    if (semver.satisfies(version, '>=0.10.0')) {
       logger.info(`Setting workspace ${chalk.green(workspace)} to A/B test`)
       const promptAnswer = await promptContinue(workspace)
 

--- a/src/modules/abtest/start.ts
+++ b/src/modules/abtest/start.ts
@@ -60,7 +60,8 @@ export default async () => {
   const workspace = await promptProductionWorkspace('Choose production workspace to start A/B test:')
 
   try {
-    const version = abTesterManifest.version.split('-')[0]
+    const [version] = abTesterManifest.version.split('-')
+
     if (semver.satisfies(version, '>=0.10.0')) {
       logger.info(`Setting workspace ${chalk.green(workspace)} to A/B test`)
       const promptAnswer = await promptContinue(workspace)


### PR DESCRIPTION
#### What is the purpose of this pull request?
To make it possible to start a test in an account that has a beta version of `ab-tester` installed.

#### What problem is this solving?
Apparently, `semver.satisfies` returns `false` whenever the version provided is not stable. 

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`