### PR TITLE
Fix / prohibit the use of old ABTester versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- [abtest] Prohibit the use of old versions of vtex.ab-tester
+
 ## [0.1.3] - 2021-04-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4] - 2021-05-05
+
 ### Fixed
 - [abtest] Prohibit the use of old versions of vtex.ab-tester
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ npm install -g @vtex/cli-plugin-abtest
 $ oclif-example COMMAND
 running command...
 $ oclif-example (-v|--version|version)
-@vtex/cli-plugin-abtest/0.1.3 linux-x64 node-v12.22.1
+@vtex/cli-plugin-abtest/0.1.4 linux-x64 node-v12.22.1
 $ oclif-example --help [COMMAND]
 USAGE
   $ oclif-example COMMAND
@@ -44,7 +44,7 @@ OPTIONS
   --trace        Ensure all requests to VTEX IO are traced
 ```
 
-_See code: [build/commands/workspace/abtest/finish.ts](https://github.com/vtex/cli-plugin-abtest/blob/v0.1.3/build/commands/workspace/abtest/finish.ts)_
+_See code: [build/commands/workspace/abtest/finish.ts](https://github.com/vtex/cli-plugin-abtest/blob/v0.1.4/build/commands/workspace/abtest/finish.ts)_
 
 ## `oclif-example workspace:abtest:start`
 
@@ -60,7 +60,7 @@ OPTIONS
   --trace        Ensure all requests to VTEX IO are traced
 ```
 
-_See code: [build/commands/workspace/abtest/start.ts](https://github.com/vtex/cli-plugin-abtest/blob/v0.1.3/build/commands/workspace/abtest/start.ts)_
+_See code: [build/commands/workspace/abtest/start.ts](https://github.com/vtex/cli-plugin-abtest/blob/v0.1.4/build/commands/workspace/abtest/start.ts)_
 
 ## `oclif-example workspace:abtest:status`
 
@@ -76,5 +76,5 @@ OPTIONS
   --trace        Ensure all requests to VTEX IO are traced
 ```
 
-_See code: [build/commands/workspace/abtest/status.ts](https://github.com/vtex/cli-plugin-abtest/blob/v0.1.3/build/commands/workspace/abtest/status.ts)_
+_See code: [build/commands/workspace/abtest/status.ts](https://github.com/vtex/cli-plugin-abtest/blob/v0.1.4/build/commands/workspace/abtest/status.ts)_
 <!-- commandsstop -->

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vtex/cli-plugin-abtest",
   "description": "vtex plugin abtest",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "bugs": "https://github.com/vtex/cli-plugin-abtest/issues",
   "dependencies": {
     "@oclif/command": "^1",

--- a/src/modules/abtest/finish.ts
+++ b/src/modules/abtest/finish.ts
@@ -5,7 +5,7 @@ import { map, prop, filter } from 'ramda'
 import { logger, promptConfirm, SessionManager } from 'vtex'
 
 import { default as abTestStatus } from './status'
-import { abtester, installedABTester } from './utils'
+import { abtester, checkABTester } from './utils'
 
 const { account } = SessionManager.getSingleton()
 
@@ -33,7 +33,7 @@ const promptWorkspaceToFinishABTest = () =>
     .then(prop('workspace'))
 
 export default async () => {
-  await installedABTester()
+  await checkABTester()
   const workspace = await promptWorkspaceToFinishABTest()
   const promptAnswer = await promptContinue(workspace)
 

--- a/src/modules/abtest/start.ts
+++ b/src/modules/abtest/start.ts
@@ -1,43 +1,14 @@
 import chalk from 'chalk'
-import enquirer from 'enquirer'
-import { compose, fromPairs, keys, map, mapObjIndexed, prop, values, zip } from 'ramda'
 
 import { logger, promptConfirm } from 'vtex'
 
 import {
   abtester,
   checkABTester,
-  formatDays,
   promptConstraintDuration,
   promptProductionWorkspace,
   promptProportionTrafic,
-  SIGNIFICANCE_LEVELS,
 } from './utils'
-
-const promptSignificanceLevel = async (): Promise<string> => {
-  const significanceTimePreviews = await Promise.all(
-    compose<any, number[], Array<Promise<number>>>(
-      map((value) => abtester.preview(value as number)),
-      values
-    )(SIGNIFICANCE_LEVELS)
-  )
-
-  const significanceTimePreviewMap = fromPairs(zip(keys(SIGNIFICANCE_LEVELS), significanceTimePreviews))
-
-  return enquirer
-    .prompt<{ level: string }>({
-      name: 'level',
-      message: 'Choose the significance level:',
-      type: 'select',
-      choices: values(
-        mapObjIndexed((value, key) => ({
-          message: `${key} (~ ${formatDays(value as number)})`,
-          value: key,
-        }))(significanceTimePreviewMap)
-      ) as any,
-    })
-    .then(prop('level'))
-}
 
 const promptContinue = (workspace: string, significanceLevel?: string) => {
   return significanceLevel

--- a/src/modules/abtest/start.ts
+++ b/src/modules/abtest/start.ts
@@ -41,7 +41,7 @@ export default async () => {
     if (err.message === 'Workspace not found') {
       console.log(`Test not initialized due to workspace ${workspace} not found by ab-tester.`)
     }
-  } 
+  }
   logger.info(`Workspace ${chalk.green(String(workspace))} in A/B test`)
   logger.info(`You can stop the test using ${chalk.blue('vtex workspace abtest finish')}`)
 

--- a/src/modules/abtest/start.ts
+++ b/src/modules/abtest/start.ts
@@ -28,23 +28,22 @@ ${chalk.green('master')} and ${chalk.green(workspace)}. Proceed?`,
 export default async () => {
   await checkABTester()
   const workspace = await promptProductionWorkspace('Choose production workspace to start A/B test:')
+  logger.info(`Setting workspace ${chalk.green(workspace)} to A/B test`)
+  const promptAnswer = await promptContinue(workspace)
+
+  if (!promptAnswer) return
+  const proportion = Number(await promptProportionTrafic())
+  const timeLength = Number(await promptConstraintDuration())
 
   try {
-    logger.info(`Setting workspace ${chalk.green(workspace)} to A/B test`)
-    const promptAnswer = await promptContinue(workspace)
-
-    if (!promptAnswer) return
-    const proportion = Number(await promptProportionTrafic())
-    const timeLength = Number(await promptConstraintDuration())
-
     await abtester.customStart(workspace, timeLength, proportion)
-    logger.info(`Workspace ${chalk.green(String(workspace))} in A/B test`)
-    logger.info(`You can stop the test using ${chalk.blue('vtex workspace abtest finish')}`)
-
-    return
   } catch (err) {
     if (err.message === 'Workspace not found') {
       console.log(`Test not initialized due to workspace ${workspace} not found by ab-tester.`)
     }
-  }
+  } 
+  logger.info(`Workspace ${chalk.green(String(workspace))} in A/B test`)
+  logger.info(`You can stop the test using ${chalk.blue('vtex workspace abtest finish')}`)
+
+  return
 }

--- a/src/modules/abtest/start.ts
+++ b/src/modules/abtest/start.ts
@@ -28,6 +28,7 @@ ${chalk.green('master')} and ${chalk.green(workspace)}. Proceed?`,
 export default async () => {
   await checkABTester()
   const workspace = await promptProductionWorkspace('Choose production workspace to start A/B test:')
+
   logger.info(`Setting workspace ${chalk.green(workspace)} to A/B test`)
   const promptAnswer = await promptContinue(workspace)
 
@@ -42,6 +43,7 @@ export default async () => {
       console.log(`Test not initialized due to workspace ${workspace} not found by ab-tester.`)
     }
   }
+
   logger.info(`Workspace ${chalk.green(String(workspace))} in A/B test`)
   logger.info(`You can stop the test using ${chalk.blue('vtex workspace abtest finish')}`)
 }

--- a/src/modules/abtest/start.ts
+++ b/src/modules/abtest/start.ts
@@ -44,6 +44,4 @@ export default async () => {
   }
   logger.info(`Workspace ${chalk.green(String(workspace))} in A/B test`)
   logger.info(`You can stop the test using ${chalk.blue('vtex workspace abtest finish')}`)
-
-  return
 }

--- a/src/modules/abtest/status.ts
+++ b/src/modules/abtest/status.ts
@@ -4,7 +4,7 @@ import numbro from 'numbro'
 import R from 'ramda'
 import { SessionManager, logger, createTable } from 'vtex'
 
-import { abtester, formatDuration, installedABTester } from './utils'
+import { abtester, formatDuration, checkABTester } from './utils'
 
 interface ABTestStatus {
   ABTestBeginning: string
@@ -119,7 +119,7 @@ const printResultsTable = (testInfo: ABTestStatus) => {
 export default async () => {
   const { account } = SessionManager.getSingleton()
 
-  await installedABTester()
+  await checkABTester()
   let abTestInfo = []
 
   abTestInfo = await abtester.status()

--- a/src/modules/abtest/utils.ts
+++ b/src/modules/abtest/utils.ts
@@ -37,6 +37,7 @@ not installed in account ${chalk.green(account)}, workspace \
 ${chalk.blue('master')}. Please install it before attempting to use A/B \
 testing functionality`)
     }
+
     throw e
   }
 }
@@ -53,6 +54,7 @@ which is of an excessively old version. Please, use a version newer than ${chalk
 
 export const checkABTester = async () => {
   const abTesterManifest = await installedABTester()
+
   checkABTesterVersion(abTesterManifest.version)
 }
 

--- a/src/modules/abtest/utils.ts
+++ b/src/modules/abtest/utils.ts
@@ -27,11 +27,6 @@ export const formatDuration = (durationInMinutes: number) => {
   return `${days} days, ${hours} hours and ${minutes} minutes`
 }
 
-export const checkABTester = async () => {
-  const abTesterManifest = await installedABTester()
-  checkABTesterVersion(abTesterManifest.version)
-}
-
 const installedABTester = async (): Promise<AppManifest> => {
   try {
     return await apps.getApp('vtex.ab-tester@x')
@@ -54,6 +49,11 @@ const checkABTesterVersion = (version: string) => {
 which is of an excessively old version. Please, use a version newer than ${chalk.green(VERSION_THRESHOLD)} \
 \nTo get the latest version, run ${chalk.hex(COLORS.PINK)('vtex install vtex.ab-tester')}`)
   }
+}
+
+export const checkABTester = async () => {
+  const abTesterManifest = await installedABTester()
+  checkABTesterVersion(abTesterManifest.version)
 }
 
 export const promptProductionWorkspace = async (promptMessage: string): Promise<string> => {

--- a/src/modules/abtest/utils.ts
+++ b/src/modules/abtest/utils.ts
@@ -1,7 +1,6 @@
 import { AppManifest } from '@vtex/api'
 import chalk from 'chalk'
 import enquirer from 'enquirer'
-import numbro from 'numbro'
 import { compose, filter, map, prop } from 'ramda'
 import * as env from 'vtex'
 import { createFlowIssueError, createAppsClient, createWorkspacesClient, SessionManager, COLORS } from 'vtex'
@@ -12,12 +11,6 @@ const VERSION_THRESHOLD = '0.12.0'
 
 const DEFAULT_TIMEOUT = 15000
 
-export const SIGNIFICANCE_LEVELS: Record<string, number> = {
-  low: 0.5,
-  mid: 0.7,
-  high: 0.9,
-}
-
 const { account } = SessionManager.getSingleton()
 
 const options = { timeout: (env.envTimeout || DEFAULT_TIMEOUT) as number }
@@ -25,16 +18,6 @@ const options = { timeout: (env.envTimeout || DEFAULT_TIMEOUT) as number }
 // Clients for the 'master' workspace
 export const abtester = ABTester.createClient({ workspace: 'master' }, { ...options, retries: 3 })
 export const apps = createAppsClient({ workspace: 'master' })
-
-export const formatDays = (days: number) => {
-  let suffix = 'days'
-
-  if (days === 1) {
-    suffix = 'day'
-  }
-
-  return `${numbro(days).format('0,0')} ${suffix}`
-}
 
 export const formatDuration = (durationInMinutes: number) => {
   const minutes = durationInMinutes % 60


### PR DESCRIPTION
#### What is the purpose of this pull request?
To prevent the user from using old versions of the ABTester.

#### What problem is this solving?
Some old versions of `vtex.ab-tester` haven't been working properly.
Also, this change will simplify the cli's code.

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`